### PR TITLE
Make CKFSession and CKFVideoSession open

### DIFF
--- a/CameraKit/CameraKit/CKFSession.swift
+++ b/CameraKit/CameraKit/CKFSession.swift
@@ -71,7 +71,7 @@ extension CKFSession.CameraPosition {
     @objc func didChangeValue(session: CKFSession, value: Any, key: String)
 }
 
-@objc public class CKFSession: NSObject {
+@objc open class CKFSession: NSObject {
     
     @objc public enum DeviceType: UInt {
         case frontCamera, backCamera, microphone

--- a/CameraKit/CameraKit/CKFVideoSession.swift
+++ b/CameraKit/CameraKit/CKFVideoSession.swift
@@ -19,7 +19,7 @@ extension CKFSession.FlashMode {
     }
 }
 
-@objc public class CKFVideoSession: CKFSession, AVCaptureFileOutputRecordingDelegate {
+@objc open class CKFVideoSession: CKFSession, AVCaptureFileOutputRecordingDelegate {
     
     @objc public private(set) var isRecording = false
     


### PR DESCRIPTION
## Proposed changes

I'm proposing to make CKFSession and CKFVideoSession to be open classes so that we can create a subclass that adjusts the AVCaptureVideoDataOutput variable (which is currently internal and unable to change) so that we can adjust the output to match what the user sees and records in facemail. 

The subclassing would be done within Fam and wouldn't add anything else to the framework. 